### PR TITLE
Adding save of latest results to consistent location

### DIFF
--- a/.github/LICENSE-LLNL
+++ b/.github/LICENSE-LLNL
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016-2017 Lawrence Livermore National Security
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,5 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.scom/vsoch/contributor-ci/tree/master) (0.0.x)
+ - save of data in "latest" folder for consistent location for site (0.0.11)
+ - first initial release with all extractors and Contributor Friendliness Assessment (0.0.1)
  - Initial creation of project (0.0.0)
 

--- a/contributor_ci/main/extractor.py
+++ b/contributor_ci/main/extractor.py
@@ -181,14 +181,19 @@ class ExtractorBase:
         results = self.get_results()
         outdir = self.get_dated_outdir()
 
-        if not os.path.exists(outdir):
-            os.makedirs(outdir)
+        # Also save as latest results
+        latest = os.path.join(self.outdir, "data", "latest")
+
+        for dirname in [latest, outdir]:
+            if not os.path.exists(dirname):
+                os.makedirs(dirname)
 
         for name, result in results.items():
-            outfile = "cci-%s.json" % name
-            outfile = os.path.join(outdir, outfile)
+            outname = "cci-%s.json" % name
             if result:
-                contributor_ci.utils.write_json(result, outfile)
+                for dirname in [outdir, latest]:
+                    outfile = os.path.join(dirname, outname)
+                    contributor_ci.utils.write_json(result, outfile)
 
 
 class GitHubExtractorBase(ExtractorBase):

--- a/contributor_ci/version.py
+++ b/contributor_ci/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2021, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
-__version__ = "0.0.1"
+__version__ = "0.0.11"
 AUTHOR = "Vanessa Sochat"
 NAME = "contributor_ci"
 PACKAGE_URL = "https://github.com/vsoch/contributor_ci"


### PR DESCRIPTION
This will close #6. It's not a symbolic link (GitHub does weird things with them) but just a duplicated save of the file, which should suffice.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>